### PR TITLE
add a node for partial_expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -20,11 +20,9 @@ module.exports = grammar({
       )
     ),
 
-    partial_expression: $ => seq(
-      choice(
-        seq(/end[\)\]\}]*/, repeat($._code)),
-        seq(repeat($._code), choice('do', '->'), optional(seq('#', repeat($._code)))),
-      ),
+    partial_expression: $ => choice(
+      seq(/end[\)\]\}]*/, repeat($._code)),
+      seq(repeat($._code), choice('do', '->'), optional(seq('#', repeat($._code)))),
     ),
 
     expression: $ => repeat1($._code),

--- a/grammar.js
+++ b/grammar.js
@@ -22,8 +22,8 @@ module.exports = grammar({
 
     partial_expression: $ => seq(
       choice(
-        seq(field("kind", alias(/end[\)\]\}]*/, "end")), repeat($._code)),
-        seq(repeat($._code), field("kind", choice("do", "->")), optional(seq("#", repeat($._code)))),
+        seq(field('kind', alias(/end[\)\]\}]*/, 'end')), repeat($._code)),
+        seq(repeat($._code), field('kind', choice('do', '->')), optional(seq('#', repeat($._code)))),
       ),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -22,8 +22,8 @@ module.exports = grammar({
 
     partial_expression: $ => seq(
       choice(
-        seq(field('kind', alias(/end[\)\]\}]*/, 'end')), repeat($._code)),
-        seq(repeat($._code), field('kind', choice('do', '->')), optional(seq('#', repeat($._code)))),
+        seq(/end[\)\]\}]*/, repeat($._code)),
+        seq(repeat($._code), choice('do', '->'), optional(seq('#', repeat($._code)))),
       ),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -20,9 +20,11 @@ module.exports = grammar({
       )
     ),
 
-    partial_expression: $ => choice(
-      seq(field("kind", alias(/end[\)\]\}]*/, "end")), repeat($._code)),
-      prec.right(seq(repeat($._code), field("kind", choice("do", "->")))),
+    partial_expression: $ => seq(
+      choice(
+        seq(field("kind", alias(/end[\)\]\}]*/, "end")), repeat($._code)),
+        seq(repeat($._code), field("kind", choice("do", "->")), optional(seq("#", repeat($._code)))),
+      ),
     ),
 
     expression: $ => repeat1($._code),

--- a/grammar.js
+++ b/grammar.js
@@ -14,11 +14,18 @@ module.exports = grammar({
       choice('<%', '<%=', '<%%', '<%%='),
       prec.left(
         seq(
-          alias(repeat($._code), 'code'),
+          optional(choice($.partial_expression, $.expression)),
           '%>',
         )
       )
     ),
+
+    partial_expression: $ => choice(
+      seq(field("kind", alias(/end[\)\]\}]*/, "end")), repeat($._code)),
+      prec.right(seq(repeat($._code), field("kind", choice("do", "->")))),
+    ),
+
+    expression: $ => repeat1($._code),
 
     comment: $ => choice($._hash_comment, $._bang_comment),
 
@@ -44,5 +51,5 @@ module.exports = grammar({
 
     text: $ => /[^<]+|</,
 
-    _code: $ => /[^%]+|%/,
+    _code: $ => /[^%\s]+|[%\s]/,
 }})

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -56,16 +56,25 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_code"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "partial_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
                   }
-                },
-                "named": false,
-                "value": "code"
+                ]
               },
               {
                 "type": "STRING",
@@ -75,6 +84,76 @@
           }
         }
       ]
+    },
+    "partial_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "kind",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "end[\\)\\]\\}]*"
+                },
+                "named": false,
+                "value": "end"
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_code"
+              }
+            }
+          ]
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_code"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "kind",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "expression": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_code"
+      }
     },
     "comment": {
       "type": "CHOICE",
@@ -153,7 +232,7 @@
     },
     "_code": {
       "type": "PATTERN",
-      "value": "[^%]+|%"
+      "value": "[^%\\s]+|[%\\s]"
     }
   },
   "extras": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -86,73 +86,68 @@
       ]
     },
     "partial_expression": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "PATTERN",
+              "value": "end[\\)\\]\\}]*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_code"
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_code"
+              }
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "PATTERN",
-                  "value": "end[\\)\\]\\}]*"
+                  "type": "STRING",
+                  "value": "do"
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_code"
-                  }
+                  "type": "STRING",
+                  "value": "->"
                 }
               ]
             },
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_code"
-                  }
-                },
-                {
-                  "type": "CHOICE",
+                  "type": "SEQ",
                   "members": [
                     {
                       "type": "STRING",
-                      "value": "do"
+                      "value": "#"
                     },
                     {
-                      "type": "STRING",
-                      "value": "->"
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_code"
+                      }
                     }
                   ]
                 },
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "_code"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "BLANK"
                 }
               ]
             }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -86,65 +86,90 @@
       ]
     },
     "partial_expression": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "kind",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "end[\\)\\]\\}]*"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "kind",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "end[\\)\\]\\}]*"
+                    },
+                    "named": false,
+                    "value": "end"
+                  }
                 },
-                "named": false,
-                "value": "end"
-              }
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_code"
+                  }
+                }
+              ]
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_code"
-              }
-            }
-          ]
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_code"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "kind",
-                "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_code"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "kind",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "do"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "->"
+                      }
+                    ]
+                  }
+                },
+                {
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": "do"
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "#"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_code"
+                          }
+                        }
+                      ]
                     },
                     {
-                      "type": "STRING",
-                      "value": "->"
+                      "type": "BLANK"
                     }
                   ]
                 }
-              }
-            ]
-          }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -95,17 +95,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "FIELD",
-                  "name": "kind",
-                  "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "end[\\)\\]\\}]*"
-                    },
-                    "named": false,
-                    "value": "end"
-                  }
+                  "type": "PATTERN",
+                  "value": "end[\\)\\]\\}]*"
                 },
                 {
                   "type": "REPEAT",
@@ -127,21 +118,17 @@
                   }
                 },
                 {
-                  "type": "FIELD",
-                  "name": "kind",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "do"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "->"
-                      }
-                    ]
-                  }
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
+                    }
+                  ]
                 },
                 {
                   "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -54,26 +54,7 @@
   {
     "type": "partial_expression",
     "named": true,
-    "fields": {
-      "kind": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "->",
-            "named": false
-          },
-          {
-            "type": "do",
-            "named": false
-          },
-          {
-            "type": "end",
-            "named": false
-          }
-        ]
-      }
-    }
+    "fields": {}
   },
   {
     "type": "#",
@@ -117,10 +98,6 @@
   },
   {
     "type": "do",
-    "named": false
-  },
-  {
-    "type": "end",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,16 +1,30 @@
 [
   {
-    "type": "code",
-    "named": false,
-    "fields": {}
-  },
-  {
     "type": "comment",
     "named": true,
     "fields": {}
   },
   {
     "type": "directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "partial_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expression",
     "named": true,
     "fields": {}
   },
@@ -38,11 +52,39 @@
     }
   },
   {
+    "type": "partial_expression",
+    "named": true,
+    "fields": {
+      "kind": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "->",
+            "named": false
+          },
+          {
+            "type": "do",
+            "named": false
+          },
+          {
+            "type": "end",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "%>",
     "named": false
   },
   {
     "type": "--%>",
+    "named": false
+  },
+  {
+    "type": "->",
     "named": false
   },
   {
@@ -67,6 +109,14 @@
   },
   {
     "type": "<%=",
+    "named": false
+  },
+  {
+    "type": "do",
+    "named": false
+  },
+  {
+    "type": "end",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -76,6 +76,10 @@
     }
   },
   {
+    "type": "#",
+    "named": false
+  },
+  {
     "type": "%>",
     "named": false
   },

--- a/src/parser.c
+++ b/src/parser.c
@@ -12,9 +12,9 @@
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 16
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 1
+#define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 3
+#define PRODUCTION_ID_COUNT 1
 
 enum {
   anon_sym_LT_PERCENT = 1,
@@ -52,7 +52,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LT_PERCENT_PERCENT] = "<%%",
   [anon_sym_LT_PERCENT_PERCENT_EQ] = "<%%=",
   [anon_sym_PERCENT_GT] = "%>",
-  [aux_sym_partial_expression_token1] = "end",
+  [aux_sym_partial_expression_token1] = "partial_expression_token1",
   [anon_sym_do] = "do",
   [anon_sym_DASH_GT] = "->",
   [anon_sym_POUND] = "#",
@@ -131,7 +131,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_partial_expression_token1] = {
-    .visible = true,
+    .visible = false,
     .named = false,
   },
   [anon_sym_do] = {
@@ -214,27 +214,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-};
-
-enum {
-  field_kind = 1,
-};
-
-static const char * const ts_field_names[] = {
-  [0] = NULL,
-  [field_kind] = "kind",
-};
-
-static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
-  [1] = {.index = 0, .length = 1},
-  [2] = {.index = 1, .length = 1},
-};
-
-static const TSFieldMapEntry ts_field_map_entries[] = {
-  [0] =
-    {field_kind, 0},
-  [1] =
-    {field_kind, 1},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -818,41 +797,41 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(25), 1,
       aux_sym_partial_expression_repeat1,
   [228] = 3,
-    ACTIONS(109), 1,
+    ACTIONS(107), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(111), 1,
+    ACTIONS(109), 1,
       sym__code,
     STATE(24), 1,
       aux_sym_partial_expression_repeat1,
   [238] = 3,
     ACTIONS(80), 1,
       sym__code,
-    ACTIONS(113), 1,
+    ACTIONS(111), 1,
       anon_sym_PERCENT_GT,
     STATE(25), 1,
       aux_sym_partial_expression_repeat1,
   [248] = 3,
     ACTIONS(67), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(115), 1,
+    ACTIONS(113), 1,
       sym__code,
     STATE(25), 1,
       aux_sym_partial_expression_repeat1,
   [258] = 2,
-    ACTIONS(118), 1,
+    ACTIONS(116), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(120), 1,
+    ACTIONS(118), 1,
       anon_sym_POUND,
   [265] = 2,
-    ACTIONS(122), 1,
+    ACTIONS(120), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(124), 1,
+    ACTIONS(122), 1,
       anon_sym_POUND,
   [272] = 1,
-    ACTIONS(126), 1,
+    ACTIONS(124), 1,
       anon_sym_PERCENT_GT,
   [276] = 1,
-    ACTIONS(128), 1,
+    ACTIONS(126), 1,
       ts_builtin_sym_end,
 };
 
@@ -929,25 +908,24 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [84] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
   [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
   [88] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 2, .production_id = 1),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 2),
   [92] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
+  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 1),
   [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
   [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
   [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
   [102] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2), SHIFT_REPEAT(21),
   [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2),
-  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 3, .production_id = 1),
-  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 3, .production_id = 2),
-  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 4, .production_id = 2),
-  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(25),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 2, .production_id = 2),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [128] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 3),
+  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [111] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 4),
+  [113] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(25),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 1),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 2),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [126] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
@@ -974,9 +952,6 @@ extern const TSLanguage *tree_sitter_eex(void) {
     .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
-    .field_names = ts_field_names,
-    .field_map_slices = ts_field_map_slices,
-    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,14 +6,14 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 26
+#define STATE_COUNT 30
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 26
+#define SYMBOL_COUNT 27
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 15
+#define TOKEN_COUNT 16
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
-#define MAX_ALIAS_SEQUENCE_LENGTH 3
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
 #define PRODUCTION_ID_COUNT 3
 
 enum {
@@ -25,23 +25,24 @@ enum {
   aux_sym_partial_expression_token1 = 6,
   anon_sym_do = 7,
   anon_sym_DASH_GT = 8,
-  anon_sym_LT_PERCENT_POUND = 9,
-  anon_sym_LT_PERCENT_BANG_DASH_DASH = 10,
-  aux_sym__bang_comment_token1 = 11,
-  anon_sym_DASH_DASH_PERCENT_GT = 12,
-  sym_text = 13,
-  sym__code = 14,
-  sym_fragment = 15,
-  sym__node = 16,
-  sym_directive = 17,
-  sym_partial_expression = 18,
-  sym_expression = 19,
-  sym_comment = 20,
-  sym__hash_comment = 21,
-  sym__bang_comment = 22,
-  aux_sym_fragment_repeat1 = 23,
-  aux_sym_partial_expression_repeat1 = 24,
-  aux_sym__bang_comment_repeat1 = 25,
+  anon_sym_POUND = 9,
+  anon_sym_LT_PERCENT_POUND = 10,
+  anon_sym_LT_PERCENT_BANG_DASH_DASH = 11,
+  aux_sym__bang_comment_token1 = 12,
+  anon_sym_DASH_DASH_PERCENT_GT = 13,
+  sym_text = 14,
+  sym__code = 15,
+  sym_fragment = 16,
+  sym__node = 17,
+  sym_directive = 18,
+  sym_partial_expression = 19,
+  sym_expression = 20,
+  sym_comment = 21,
+  sym__hash_comment = 22,
+  sym__bang_comment = 23,
+  aux_sym_fragment_repeat1 = 24,
+  aux_sym_partial_expression_repeat1 = 25,
+  aux_sym__bang_comment_repeat1 = 26,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -54,6 +55,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_partial_expression_token1] = "end",
   [anon_sym_do] = "do",
   [anon_sym_DASH_GT] = "->",
+  [anon_sym_POUND] = "#",
   [anon_sym_LT_PERCENT_POUND] = "<%#",
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = "<%!--",
   [aux_sym__bang_comment_token1] = "_bang_comment_token1",
@@ -83,6 +85,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_partial_expression_token1] = aux_sym_partial_expression_token1,
   [anon_sym_do] = anon_sym_do,
   [anon_sym_DASH_GT] = anon_sym_DASH_GT,
+  [anon_sym_POUND] = anon_sym_POUND,
   [anon_sym_LT_PERCENT_POUND] = anon_sym_LT_PERCENT_POUND,
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = anon_sym_LT_PERCENT_BANG_DASH_DASH,
   [aux_sym__bang_comment_token1] = aux_sym__bang_comment_token1,
@@ -136,6 +139,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUND] = {
     .visible = true,
     .named = false,
   },
@@ -244,6 +251,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(16);
+      if (lookahead == '#') ADVANCE(28);
       if (lookahead == '%') ADVANCE(10);
       if (lookahead == '-') ADVANCE(8);
       if (lookahead == '<') ADVANCE(1);
@@ -258,47 +266,47 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '%') ADVANCE(17);
       END_STATE();
     case 2:
-      if (lookahead == '%') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'd') ADVANCE(44);
-      if (lookahead == 'e') ADVANCE(43);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(37);
-      if (lookahead != 0) ADVANCE(45);
-      END_STATE();
-    case 3:
-      if (lookahead == '%') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '-') ADVANCE(42);
+      if (lookahead == 'd') ADVANCE(45);
+      if (lookahead == 'e') ADVANCE(44);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(38);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead != 0) ADVANCE(46);
       END_STATE();
-    case 4:
-      if (lookahead == '%') ADVANCE(40);
+    case 3:
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '-') ADVANCE(42);
+      if (lookahead == 'd') ADVANCE(45);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(39);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead != 0) ADVANCE(46);
+      END_STATE();
+    case 4:
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(40);
+      if (lookahead != 0) ADVANCE(46);
       END_STATE();
     case 5:
       if (lookahead == '%') ADVANCE(11);
       END_STATE();
     case 6:
-      if (lookahead == '-') ADVANCE(29);
+      if (lookahead == '-') ADVANCE(30);
       END_STATE();
     case 7:
-      if (lookahead == '-') ADVANCE(31);
+      if (lookahead == '-') ADVANCE(32);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(30);
-      if (lookahead != 0) ADVANCE(32);
+          lookahead == ' ') ADVANCE(31);
+      if (lookahead != 0) ADVANCE(33);
       END_STATE();
     case 8:
       if (lookahead == '-') ADVANCE(5);
@@ -311,7 +319,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '>') ADVANCE(21);
       END_STATE();
     case 11:
-      if (lookahead == '>') ADVANCE(33);
+      if (lookahead == '>') ADVANCE(34);
       END_STATE();
     case 12:
       if (lookahead == 'd') ADVANCE(22);
@@ -324,12 +332,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 15:
       if (eof) ADVANCE(16);
-      if (lookahead == '<') ADVANCE(34);
+      if (lookahead == '<') ADVANCE(35);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
-      if (lookahead != 0) ADVANCE(36);
+          lookahead == ' ') ADVANCE(36);
+      if (lookahead != 0) ADVANCE(37);
       END_STATE();
     case 16:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -337,7 +345,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 17:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT);
       if (lookahead == '!') ADVANCE(9);
-      if (lookahead == '#') ADVANCE(28);
+      if (lookahead == '#') ADVANCE(29);
       if (lookahead == '%') ADVANCE(19);
       if (lookahead == '=') ADVANCE(18);
       END_STATE();
@@ -370,7 +378,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
     case 24:
       ACCEPT_TOKEN(anon_sym_do);
@@ -382,7 +390,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
     case 26:
       ACCEPT_TOKEN(anon_sym_DASH_GT);
@@ -394,90 +402,93 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead == '-') ADVANCE(31);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(30);
-      if (lookahead != 0) ADVANCE(32);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead == '-') ADVANCE(5);
+      if (lookahead == '-') ADVANCE(32);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(31);
+      if (lookahead != 0) ADVANCE(33);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '-') ADVANCE(32);
+      if (lookahead == '-') ADVANCE(5);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
+      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '-') ADVANCE(33);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '%') ADVANCE(17);
+      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == '<') ADVANCE(34);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
-      if (lookahead != 0) ADVANCE(36);
+      if (lookahead == '%') ADVANCE(17);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(36);
-      END_STATE();
-    case 37:
-      ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'd') ADVANCE(44);
-      if (lookahead == 'e') ADVANCE(43);
+      if (lookahead == '<') ADVANCE(35);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(37);
-      if (lookahead != 0) ADVANCE(45);
+          lookahead == ' ') ADVANCE(36);
+      if (lookahead != 0) ADVANCE(37);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '<') ADVANCE(37);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '-') ADVANCE(42);
+      if (lookahead == 'd') ADVANCE(45);
+      if (lookahead == 'e') ADVANCE(44);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(38);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead != 0) ADVANCE(46);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '-') ADVANCE(42);
+      if (lookahead == 'd') ADVANCE(45);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(39);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead != 0) ADVANCE(46);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '>') ADVANCE(21);
+      if (lookahead == '%') ADVANCE(41);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(40);
+      if (lookahead != 0) ADVANCE(46);
       END_STATE();
     case 41:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(21);
+      END_STATE();
+    case 42:
       ACCEPT_TOKEN(sym__code);
       if (lookahead == '>') ADVANCE(27);
       if (lookahead != 0 &&
@@ -485,9 +496,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
-    case 42:
+    case 43:
       ACCEPT_TOKEN(sym__code);
       if (lookahead == 'd') ADVANCE(23);
       if (lookahead != 0 &&
@@ -495,19 +506,19 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
-    case 43:
+    case 44:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == 'n') ADVANCE(42);
+      if (lookahead == 'n') ADVANCE(43);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
-    case 44:
+    case 45:
       ACCEPT_TOKEN(sym__code);
       if (lookahead == 'o') ADVANCE(25);
       if (lookahead != 0 &&
@@ -515,16 +526,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
-    case 45:
+    case 46:
       ACCEPT_TOKEN(sym__code);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(45);
+          lookahead != '%') ADVANCE(46);
       END_STATE();
     default:
       return false;
@@ -551,13 +562,17 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [16] = {.lex_state = 7},
   [17] = {.lex_state = 4},
   [18] = {.lex_state = 4},
-  [19] = {.lex_state = 7},
+  [19] = {.lex_state = 4},
   [20] = {.lex_state = 7},
-  [21] = {.lex_state = 4},
-  [22] = {.lex_state = 0},
-  [23] = {.lex_state = 0},
-  [24] = {.lex_state = 0},
-  [25] = {.lex_state = 0},
+  [21] = {.lex_state = 7},
+  [22] = {.lex_state = 4},
+  [23] = {.lex_state = 4},
+  [24] = {.lex_state = 4},
+  [25] = {.lex_state = 4},
+  [26] = {.lex_state = 0},
+  [27] = {.lex_state = 0},
+  [28] = {.lex_state = 0},
+  [29] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -571,17 +586,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_partial_expression_token1] = ACTIONS(1),
     [anon_sym_do] = ACTIONS(1),
     [anon_sym_DASH_GT] = ACTIONS(1),
+    [anon_sym_POUND] = ACTIONS(1),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(1),
     [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(1),
     [anon_sym_DASH_DASH_PERCENT_GT] = ACTIONS(1),
   },
   [1] = {
-    [sym_fragment] = STATE(25),
+    [sym_fragment] = STATE(29),
     [sym__node] = STATE(2),
     [sym_directive] = STATE(2),
     [sym_comment] = STATE(2),
-    [sym__hash_comment] = STATE(8),
-    [sym__bang_comment] = STATE(8),
+    [sym__hash_comment] = STATE(7),
+    [sym__bang_comment] = STATE(7),
     [aux_sym_fragment_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(3),
     [anon_sym_LT_PERCENT] = ACTIONS(5),
@@ -596,8 +612,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__node] = STATE(3),
     [sym_directive] = STATE(3),
     [sym_comment] = STATE(3),
-    [sym__hash_comment] = STATE(8),
-    [sym__bang_comment] = STATE(8),
+    [sym__hash_comment] = STATE(7),
+    [sym__bang_comment] = STATE(7),
     [aux_sym_fragment_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(13),
     [anon_sym_LT_PERCENT] = ACTIONS(5),
@@ -612,8 +628,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__node] = STATE(3),
     [sym_directive] = STATE(3),
     [sym_comment] = STATE(3),
-    [sym__hash_comment] = STATE(8),
-    [sym__bang_comment] = STATE(8),
+    [sym__hash_comment] = STATE(7),
+    [sym__bang_comment] = STATE(7),
     [aux_sym_fragment_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(17),
     [anon_sym_LT_PERCENT] = ACTIONS(19),
@@ -634,12 +650,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_partial_expression_token1,
     ACTIONS(37), 1,
       sym__code,
-    STATE(12), 1,
+    STATE(13), 1,
       aux_sym_partial_expression_repeat1,
     ACTIONS(35), 2,
       anon_sym_do,
       anon_sym_DASH_GT,
-    STATE(22), 2,
+    STATE(28), 2,
       sym_partial_expression,
       sym_expression,
   [21] = 2,
@@ -719,23 +735,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [112] = 4,
-    ACTIONS(67), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(71), 1,
+  [112] = 3,
+    ACTIONS(69), 1,
       sym__code,
-    STATE(13), 1,
+    STATE(12), 1,
       aux_sym_partial_expression_repeat1,
-    ACTIONS(69), 2,
+    ACTIONS(67), 3,
+      anon_sym_PERCENT_GT,
       anon_sym_do,
       anon_sym_DASH_GT,
-  [126] = 3,
-    ACTIONS(75), 1,
-      sym__code,
-    STATE(13), 1,
-      aux_sym_partial_expression_repeat1,
-    ACTIONS(73), 3,
+  [124] = 4,
+    ACTIONS(72), 1,
       anon_sym_PERCENT_GT,
+    ACTIONS(76), 1,
+      sym__code,
+    STATE(12), 1,
+      aux_sym_partial_expression_repeat1,
+    ACTIONS(74), 2,
       anon_sym_do,
       anon_sym_DASH_GT,
   [138] = 3,
@@ -743,68 +759,100 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT_GT,
     ACTIONS(80), 1,
       sym__code,
-    STATE(15), 1,
+    STATE(25), 1,
       aux_sym_partial_expression_repeat1,
   [148] = 3,
     ACTIONS(82), 1,
       anon_sym_PERCENT_GT,
     ACTIONS(84), 1,
       sym__code,
-    STATE(21), 1,
+    STATE(14), 1,
       aux_sym_partial_expression_repeat1,
   [158] = 3,
     ACTIONS(86), 1,
       aux_sym__bang_comment_token1,
     ACTIONS(88), 1,
       anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(20), 1,
+    STATE(21), 1,
       aux_sym__bang_comment_repeat1,
   [168] = 3,
-    ACTIONS(84), 1,
+    ACTIONS(80), 1,
       sym__code,
     ACTIONS(90), 1,
       anon_sym_PERCENT_GT,
-    STATE(21), 1,
+    STATE(25), 1,
       aux_sym_partial_expression_repeat1,
   [178] = 3,
-    ACTIONS(92), 1,
+    ACTIONS(90), 1,
       anon_sym_PERCENT_GT,
+    ACTIONS(92), 1,
+      sym__code,
+    STATE(22), 1,
+      aux_sym_partial_expression_repeat1,
+  [188] = 3,
     ACTIONS(94), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(96), 1,
       sym__code,
     STATE(17), 1,
       aux_sym_partial_expression_repeat1,
-  [188] = 3,
-    ACTIONS(96), 1,
-      aux_sym__bang_comment_token1,
+  [198] = 3,
     ACTIONS(98), 1,
+      aux_sym__bang_comment_token1,
+    ACTIONS(100), 1,
       anon_sym_DASH_DASH_PERCENT_GT,
     STATE(16), 1,
       aux_sym__bang_comment_repeat1,
-  [198] = 3,
-    ACTIONS(100), 1,
-      aux_sym__bang_comment_token1,
-    ACTIONS(103), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(20), 1,
-      aux_sym__bang_comment_repeat1,
   [208] = 3,
-    ACTIONS(73), 1,
-      anon_sym_PERCENT_GT,
+    ACTIONS(102), 1,
+      aux_sym__bang_comment_token1,
     ACTIONS(105), 1,
-      sym__code,
+      anon_sym_DASH_DASH_PERCENT_GT,
     STATE(21), 1,
+      aux_sym__bang_comment_repeat1,
+  [218] = 3,
+    ACTIONS(80), 1,
+      sym__code,
+    ACTIONS(107), 1,
+      anon_sym_PERCENT_GT,
+    STATE(25), 1,
       aux_sym_partial_expression_repeat1,
-  [218] = 1,
-    ACTIONS(108), 1,
+  [228] = 3,
+    ACTIONS(109), 1,
       anon_sym_PERCENT_GT,
-  [222] = 1,
-    ACTIONS(110), 1,
+    ACTIONS(111), 1,
+      sym__code,
+    STATE(24), 1,
+      aux_sym_partial_expression_repeat1,
+  [238] = 3,
+    ACTIONS(80), 1,
+      sym__code,
+    ACTIONS(113), 1,
       anon_sym_PERCENT_GT,
-  [226] = 1,
-    ACTIONS(112), 1,
+    STATE(25), 1,
+      aux_sym_partial_expression_repeat1,
+  [248] = 3,
+    ACTIONS(67), 1,
       anon_sym_PERCENT_GT,
-  [230] = 1,
-    ACTIONS(114), 1,
+    ACTIONS(115), 1,
+      sym__code,
+    STATE(25), 1,
+      aux_sym_partial_expression_repeat1,
+  [258] = 2,
+    ACTIONS(118), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(120), 1,
+      anon_sym_POUND,
+  [265] = 2,
+    ACTIONS(122), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(124), 1,
+      anon_sym_POUND,
+  [272] = 1,
+    ACTIONS(126), 1,
+      anon_sym_PERCENT_GT,
+  [276] = 1,
+    ACTIONS(128), 1,
       ts_builtin_sym_end,
 };
 
@@ -818,7 +866,7 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(10)] = 86,
   [SMALL_STATE(11)] = 99,
   [SMALL_STATE(12)] = 112,
-  [SMALL_STATE(13)] = 126,
+  [SMALL_STATE(13)] = 124,
   [SMALL_STATE(14)] = 138,
   [SMALL_STATE(15)] = 148,
   [SMALL_STATE(16)] = 158,
@@ -828,9 +876,13 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(20)] = 198,
   [SMALL_STATE(21)] = 208,
   [SMALL_STATE(22)] = 218,
-  [SMALL_STATE(23)] = 222,
-  [SMALL_STATE(24)] = 226,
-  [SMALL_STATE(25)] = 230,
+  [SMALL_STATE(23)] = 228,
+  [SMALL_STATE(24)] = 238,
+  [SMALL_STATE(25)] = 248,
+  [SMALL_STATE(26)] = 258,
+  [SMALL_STATE(27)] = 265,
+  [SMALL_STATE(28)] = 272,
+  [SMALL_STATE(29)] = 276,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -838,57 +890,64 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
   [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
   [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
   [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
   [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
   [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
   [19] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(4),
-  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(14),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(19),
+  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(15),
+  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(20),
   [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(3),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
   [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
   [41] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
   [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
   [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
-  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
-  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2),
-  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
+  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2),
+  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2),
+  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
+  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
   [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 2),
   [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 2),
   [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 2),
   [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 2),
-  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 1),
-  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2),
-  [75] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(13),
-  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [82] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
-  [84] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2),
+  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(12),
+  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 1),
+  [74] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [82] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [84] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
   [88] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
   [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 2, .production_id = 1),
-  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
-  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2), SHIFT_REPEAT(20),
-  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2),
-  [105] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(21),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 2, .production_id = 2),
-  [114] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [92] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
+  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [102] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2), SHIFT_REPEAT(21),
+  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2),
+  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 3, .production_id = 1),
+  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 3, .production_id = 2),
+  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 4, .production_id = 2),
+  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(25),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
+  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 2, .production_id = 2),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [128] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,15 +6,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 21
+#define STATE_COUNT 26
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 21
-#define ALIAS_COUNT 1
-#define TOKEN_COUNT 12
+#define SYMBOL_COUNT 26
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 15
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 0
+#define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 3
-#define PRODUCTION_ID_COUNT 2
+#define PRODUCTION_ID_COUNT 3
 
 enum {
   anon_sym_LT_PERCENT = 1,
@@ -22,22 +22,26 @@ enum {
   anon_sym_LT_PERCENT_PERCENT = 3,
   anon_sym_LT_PERCENT_PERCENT_EQ = 4,
   anon_sym_PERCENT_GT = 5,
-  anon_sym_LT_PERCENT_POUND = 6,
-  anon_sym_LT_PERCENT_BANG_DASH_DASH = 7,
-  aux_sym__bang_comment_token1 = 8,
-  anon_sym_DASH_DASH_PERCENT_GT = 9,
-  sym_text = 10,
-  sym__code = 11,
-  sym_fragment = 12,
-  sym__node = 13,
-  sym_directive = 14,
-  sym_comment = 15,
-  sym__hash_comment = 16,
-  sym__bang_comment = 17,
-  aux_sym_fragment_repeat1 = 18,
-  aux_sym_directive_repeat1 = 19,
-  aux_sym__bang_comment_repeat1 = 20,
-  anon_alias_sym_code = 21,
+  aux_sym_partial_expression_token1 = 6,
+  anon_sym_do = 7,
+  anon_sym_DASH_GT = 8,
+  anon_sym_LT_PERCENT_POUND = 9,
+  anon_sym_LT_PERCENT_BANG_DASH_DASH = 10,
+  aux_sym__bang_comment_token1 = 11,
+  anon_sym_DASH_DASH_PERCENT_GT = 12,
+  sym_text = 13,
+  sym__code = 14,
+  sym_fragment = 15,
+  sym__node = 16,
+  sym_directive = 17,
+  sym_partial_expression = 18,
+  sym_expression = 19,
+  sym_comment = 20,
+  sym__hash_comment = 21,
+  sym__bang_comment = 22,
+  aux_sym_fragment_repeat1 = 23,
+  aux_sym_partial_expression_repeat1 = 24,
+  aux_sym__bang_comment_repeat1 = 25,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -47,6 +51,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LT_PERCENT_PERCENT] = "<%%",
   [anon_sym_LT_PERCENT_PERCENT_EQ] = "<%%=",
   [anon_sym_PERCENT_GT] = "%>",
+  [aux_sym_partial_expression_token1] = "end",
+  [anon_sym_do] = "do",
+  [anon_sym_DASH_GT] = "->",
   [anon_sym_LT_PERCENT_POUND] = "<%#",
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = "<%!--",
   [aux_sym__bang_comment_token1] = "_bang_comment_token1",
@@ -56,13 +63,14 @@ static const char * const ts_symbol_names[] = {
   [sym_fragment] = "fragment",
   [sym__node] = "_node",
   [sym_directive] = "directive",
+  [sym_partial_expression] = "partial_expression",
+  [sym_expression] = "expression",
   [sym_comment] = "comment",
   [sym__hash_comment] = "_hash_comment",
   [sym__bang_comment] = "_bang_comment",
   [aux_sym_fragment_repeat1] = "fragment_repeat1",
-  [aux_sym_directive_repeat1] = "directive_repeat1",
+  [aux_sym_partial_expression_repeat1] = "partial_expression_repeat1",
   [aux_sym__bang_comment_repeat1] = "_bang_comment_repeat1",
-  [anon_alias_sym_code] = "code",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -72,6 +80,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LT_PERCENT_PERCENT] = anon_sym_LT_PERCENT_PERCENT,
   [anon_sym_LT_PERCENT_PERCENT_EQ] = anon_sym_LT_PERCENT_PERCENT_EQ,
   [anon_sym_PERCENT_GT] = anon_sym_PERCENT_GT,
+  [aux_sym_partial_expression_token1] = aux_sym_partial_expression_token1,
+  [anon_sym_do] = anon_sym_do,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
   [anon_sym_LT_PERCENT_POUND] = anon_sym_LT_PERCENT_POUND,
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = anon_sym_LT_PERCENT_BANG_DASH_DASH,
   [aux_sym__bang_comment_token1] = aux_sym__bang_comment_token1,
@@ -81,13 +92,14 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_fragment] = sym_fragment,
   [sym__node] = sym__node,
   [sym_directive] = sym_directive,
+  [sym_partial_expression] = sym_partial_expression,
+  [sym_expression] = sym_expression,
   [sym_comment] = sym_comment,
   [sym__hash_comment] = sym__hash_comment,
   [sym__bang_comment] = sym__bang_comment,
   [aux_sym_fragment_repeat1] = aux_sym_fragment_repeat1,
-  [aux_sym_directive_repeat1] = aux_sym_directive_repeat1,
+  [aux_sym_partial_expression_repeat1] = aux_sym_partial_expression_repeat1,
   [aux_sym__bang_comment_repeat1] = aux_sym__bang_comment_repeat1,
-  [anon_alias_sym_code] = anon_alias_sym_code,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -112,6 +124,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_PERCENT_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_partial_expression_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_do] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
     .visible = true,
     .named = false,
   },
@@ -151,6 +175,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_partial_expression] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_expression] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_comment] = {
     .visible = true,
     .named = true,
@@ -167,7 +199,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_directive_repeat1] = {
+  [aux_sym_partial_expression_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -175,23 +207,34 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [anon_alias_sym_code] = {
-    .visible = true,
-    .named = false,
-  },
+};
+
+enum {
+  field_kind = 1,
+};
+
+static const char * const ts_field_names[] = {
+  [0] = NULL,
+  [field_kind] = "kind",
+};
+
+static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
+  [1] = {.index = 0, .length = 1},
+  [2] = {.index = 1, .length = 1},
+};
+
+static const TSFieldMapEntry ts_field_map_entries[] = {
+  [0] =
+    {field_kind, 0},
+  [1] =
+    {field_kind, 1},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
-  [1] = {
-    [1] = anon_alias_sym_code,
-  },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
-  aux_sym_directive_repeat1, 2,
-    aux_sym_directive_repeat1,
-    anon_alias_sym_code,
   0,
 };
 
@@ -200,146 +243,288 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(11);
-      if (lookahead == '%') ADVANCE(8);
-      if (lookahead == '-') ADVANCE(6);
+      if (eof) ADVANCE(16);
+      if (lookahead == '%') ADVANCE(10);
+      if (lookahead == '-') ADVANCE(8);
       if (lookahead == '<') ADVANCE(1);
+      if (lookahead == 'd') ADVANCE(14);
+      if (lookahead == 'e') ADVANCE(13);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       END_STATE();
     case 1:
-      if (lookahead == '%') ADVANCE(12);
+      if (lookahead == '%') ADVANCE(17);
       END_STATE();
     case 2:
-      if (lookahead == '%') ADVANCE(27);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '-') ADVANCE(41);
+      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == 'e') ADVANCE(43);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(26);
-      if (lookahead != 0) ADVANCE(28);
+          lookahead == ' ') ADVANCE(37);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 3:
-      if (lookahead == '%') ADVANCE(9);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '-') ADVANCE(41);
+      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(38);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 4:
-      if (lookahead == '-') ADVANCE(18);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(39);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 5:
-      if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(19);
-      if (lookahead != 0) ADVANCE(21);
+      if (lookahead == '%') ADVANCE(11);
       END_STATE();
     case 6:
-      if (lookahead == '-') ADVANCE(3);
+      if (lookahead == '-') ADVANCE(29);
       END_STATE();
     case 7:
-      if (lookahead == '-') ADVANCE(4);
+      if (lookahead == '-') ADVANCE(31);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(30);
+      if (lookahead != 0) ADVANCE(32);
       END_STATE();
     case 8:
-      if (lookahead == '>') ADVANCE(16);
+      if (lookahead == '-') ADVANCE(5);
+      if (lookahead == '>') ADVANCE(26);
       END_STATE();
     case 9:
-      if (lookahead == '>') ADVANCE(22);
+      if (lookahead == '-') ADVANCE(6);
       END_STATE();
     case 10:
-      if (eof) ADVANCE(11);
-      if (lookahead == '<') ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(25);
+      if (lookahead == '>') ADVANCE(21);
       END_STATE();
     case 11:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == '>') ADVANCE(33);
       END_STATE();
     case 12:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '!') ADVANCE(7);
-      if (lookahead == '#') ADVANCE(17);
-      if (lookahead == '%') ADVANCE(14);
-      if (lookahead == '=') ADVANCE(13);
+      if (lookahead == 'd') ADVANCE(22);
       END_STATE();
     case 13:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
+      if (lookahead == 'n') ADVANCE(12);
       END_STATE();
     case 14:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
-      if (lookahead == '=') ADVANCE(15);
+      if (lookahead == 'o') ADVANCE(24);
       END_STATE();
     case 15:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
+      if (eof) ADVANCE(16);
+      if (lookahead == '<') ADVANCE(34);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(35);
+      if (lookahead != 0) ADVANCE(36);
       END_STATE();
     case 16:
-      ACCEPT_TOKEN(anon_sym_PERCENT_GT);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
+      if (lookahead == '!') ADVANCE(9);
+      if (lookahead == '#') ADVANCE(28);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '=') ADVANCE(18);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead == '-') ADVANCE(20);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(19);
-      if (lookahead != 0) ADVANCE(21);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
+      if (lookahead == '=') ADVANCE(20);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead == '-') ADVANCE(3);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '-') ADVANCE(21);
+      ACCEPT_TOKEN(anon_sym_PERCENT_GT);
       END_STATE();
     case 22:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
+      ACCEPT_TOKEN(aux_sym_partial_expression_token1);
+      if (lookahead == ')' ||
+          lookahead == ']' ||
+          lookahead == '}') ADVANCE(22);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '%') ADVANCE(12);
+      ACCEPT_TOKEN(aux_sym_partial_expression_token1);
+      if (lookahead == ')' ||
+          lookahead == ']' ||
+          lookahead == '}') ADVANCE(23);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '<') ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(25);
+      ACCEPT_TOKEN(anon_sym_do);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(sym_text);
+      ACCEPT_TOKEN(anon_sym_do);
       if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(25);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(27);
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 27:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
+      if (lookahead == '-') ADVANCE(31);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(26);
-      if (lookahead != 0) ADVANCE(28);
+          lookahead == ' ') ADVANCE(30);
+      if (lookahead != 0) ADVANCE(32);
       END_STATE();
-    case 27:
+    case 31:
+      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
+      if (lookahead == '-') ADVANCE(5);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(aux_sym__bang_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '-') ADVANCE(32);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '%') ADVANCE(17);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '<') ADVANCE(34);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(35);
+      if (lookahead != 0) ADVANCE(36);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '<') ADVANCE(36);
+      END_STATE();
+    case 37:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '>') ADVANCE(16);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '-') ADVANCE(41);
+      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == 'e') ADVANCE(43);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(37);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
-    case 28:
+    case 38:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '-') ADVANCE(41);
+      if (lookahead == 'd') ADVANCE(44);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(38);
+      if (lookahead != 0) ADVANCE(45);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(40);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(39);
+      if (lookahead != 0) ADVANCE(45);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(21);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(27);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'd') ADVANCE(23);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'n') ADVANCE(42);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'o') ADVANCE(25);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
+      END_STATE();
+    case 45:
       ACCEPT_TOKEN(sym__code);
       if (lookahead != 0 &&
-          lookahead != '%') ADVANCE(28);
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(45);
       END_STATE();
     default:
       return false;
@@ -348,26 +533,31 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 10},
-  [2] = {.lex_state = 10},
-  [3] = {.lex_state = 10},
-  [4] = {.lex_state = 10},
-  [5] = {.lex_state = 10},
-  [6] = {.lex_state = 10},
-  [7] = {.lex_state = 10},
-  [8] = {.lex_state = 10},
-  [9] = {.lex_state = 10},
-  [10] = {.lex_state = 10},
-  [11] = {.lex_state = 2},
-  [12] = {.lex_state = 2},
-  [13] = {.lex_state = 2},
-  [14] = {.lex_state = 5},
-  [15] = {.lex_state = 2},
-  [16] = {.lex_state = 5},
-  [17] = {.lex_state = 2},
-  [18] = {.lex_state = 5},
-  [19] = {.lex_state = 2},
-  [20] = {.lex_state = 0},
+  [1] = {.lex_state = 15},
+  [2] = {.lex_state = 15},
+  [3] = {.lex_state = 15},
+  [4] = {.lex_state = 2},
+  [5] = {.lex_state = 15},
+  [6] = {.lex_state = 15},
+  [7] = {.lex_state = 15},
+  [8] = {.lex_state = 15},
+  [9] = {.lex_state = 15},
+  [10] = {.lex_state = 15},
+  [11] = {.lex_state = 15},
+  [12] = {.lex_state = 3},
+  [13] = {.lex_state = 3},
+  [14] = {.lex_state = 4},
+  [15] = {.lex_state = 4},
+  [16] = {.lex_state = 7},
+  [17] = {.lex_state = 4},
+  [18] = {.lex_state = 4},
+  [19] = {.lex_state = 7},
+  [20] = {.lex_state = 7},
+  [21] = {.lex_state = 4},
+  [22] = {.lex_state = 0},
+  [23] = {.lex_state = 0},
+  [24] = {.lex_state = 0},
+  [25] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -378,18 +568,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_PERCENT_EQ] = ACTIONS(1),
     [anon_sym_PERCENT_GT] = ACTIONS(1),
+    [aux_sym_partial_expression_token1] = ACTIONS(1),
+    [anon_sym_do] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(1),
     [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(1),
     [anon_sym_DASH_DASH_PERCENT_GT] = ACTIONS(1),
   },
   [1] = {
-    [sym_fragment] = STATE(20),
-    [sym__node] = STATE(3),
-    [sym_directive] = STATE(3),
-    [sym_comment] = STATE(3),
+    [sym_fragment] = STATE(25),
+    [sym__node] = STATE(2),
+    [sym_directive] = STATE(2),
+    [sym_comment] = STATE(2),
     [sym__hash_comment] = STATE(8),
     [sym__bang_comment] = STATE(8),
-    [aux_sym_fragment_repeat1] = STATE(3),
+    [aux_sym_fragment_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(3),
     [anon_sym_LT_PERCENT] = ACTIONS(5),
     [anon_sym_LT_PERCENT_EQ] = ACTIONS(5),
@@ -400,63 +593,56 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_text] = ACTIONS(11),
   },
   [2] = {
-    [sym__node] = STATE(2),
-    [sym_directive] = STATE(2),
-    [sym_comment] = STATE(2),
+    [sym__node] = STATE(3),
+    [sym_directive] = STATE(3),
+    [sym_comment] = STATE(3),
     [sym__hash_comment] = STATE(8),
     [sym__bang_comment] = STATE(8),
-    [aux_sym_fragment_repeat1] = STATE(2),
+    [aux_sym_fragment_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(13),
-    [anon_sym_LT_PERCENT] = ACTIONS(15),
-    [anon_sym_LT_PERCENT_EQ] = ACTIONS(15),
-    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(15),
-    [anon_sym_LT_PERCENT_PERCENT_EQ] = ACTIONS(15),
-    [anon_sym_LT_PERCENT_POUND] = ACTIONS(18),
-    [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(21),
-    [sym_text] = ACTIONS(24),
-  },
-  [3] = {
-    [sym__node] = STATE(2),
-    [sym_directive] = STATE(2),
-    [sym_comment] = STATE(2),
-    [sym__hash_comment] = STATE(8),
-    [sym__bang_comment] = STATE(8),
-    [aux_sym_fragment_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(27),
     [anon_sym_LT_PERCENT] = ACTIONS(5),
     [anon_sym_LT_PERCENT_EQ] = ACTIONS(5),
     [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(5),
     [anon_sym_LT_PERCENT_PERCENT_EQ] = ACTIONS(5),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(7),
     [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(9),
-    [sym_text] = ACTIONS(29),
+    [sym_text] = ACTIONS(15),
+  },
+  [3] = {
+    [sym__node] = STATE(3),
+    [sym_directive] = STATE(3),
+    [sym_comment] = STATE(3),
+    [sym__hash_comment] = STATE(8),
+    [sym__bang_comment] = STATE(8),
+    [aux_sym_fragment_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(17),
+    [anon_sym_LT_PERCENT] = ACTIONS(19),
+    [anon_sym_LT_PERCENT_EQ] = ACTIONS(19),
+    [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(19),
+    [anon_sym_LT_PERCENT_PERCENT_EQ] = ACTIONS(19),
+    [anon_sym_LT_PERCENT_POUND] = ACTIONS(22),
+    [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(25),
+    [sym_text] = ACTIONS(28),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 2,
+  [0] = 6,
     ACTIONS(31), 1,
-      ts_builtin_sym_end,
-    ACTIONS(33), 7,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_POUND,
-      anon_sym_LT_PERCENT_BANG_DASH_DASH,
-      sym_text,
-  [13] = 2,
-    ACTIONS(35), 1,
-      ts_builtin_sym_end,
-    ACTIONS(37), 7,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_PERCENT,
-      anon_sym_LT_PERCENT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_POUND,
-      anon_sym_LT_PERCENT_BANG_DASH_DASH,
-      sym_text,
-  [26] = 2,
+      anon_sym_PERCENT_GT,
+    ACTIONS(33), 1,
+      aux_sym_partial_expression_token1,
+    ACTIONS(37), 1,
+      sym__code,
+    STATE(12), 1,
+      aux_sym_partial_expression_repeat1,
+    ACTIONS(35), 2,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+    STATE(22), 2,
+      sym_partial_expression,
+      sym_expression,
+  [21] = 2,
     ACTIONS(39), 1,
       ts_builtin_sym_end,
     ACTIONS(41), 7,
@@ -467,7 +653,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [39] = 2,
+  [34] = 2,
     ACTIONS(43), 1,
       ts_builtin_sym_end,
     ACTIONS(45), 7,
@@ -478,7 +664,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [52] = 2,
+  [47] = 2,
     ACTIONS(47), 1,
       ts_builtin_sym_end,
     ACTIONS(49), 7,
@@ -489,7 +675,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [65] = 2,
+  [60] = 2,
     ACTIONS(51), 1,
       ts_builtin_sym_end,
     ACTIONS(53), 7,
@@ -500,7 +686,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [78] = 2,
+  [73] = 2,
     ACTIONS(55), 1,
       ts_builtin_sym_end,
     ACTIONS(57), 7,
@@ -511,135 +697,198 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
       anon_sym_LT_PERCENT_BANG_DASH_DASH,
       sym_text,
-  [91] = 3,
+  [86] = 2,
     ACTIONS(59), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(61), 1,
-      sym__code,
-    STATE(15), 1,
-      aux_sym_directive_repeat1,
-  [101] = 3,
-    ACTIONS(61), 1,
-      sym__code,
+      ts_builtin_sym_end,
+    ACTIONS(61), 7,
+      anon_sym_LT_PERCENT,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENT_BANG_DASH_DASH,
+      sym_text,
+  [99] = 2,
     ACTIONS(63), 1,
-      anon_sym_PERCENT_GT,
-    STATE(15), 1,
-      aux_sym_directive_repeat1,
-  [111] = 3,
-    ACTIONS(61), 1,
-      sym__code,
-    ACTIONS(65), 1,
-      anon_sym_PERCENT_GT,
-    STATE(11), 1,
-      aux_sym_directive_repeat1,
-  [121] = 3,
+      ts_builtin_sym_end,
+    ACTIONS(65), 7,
+      anon_sym_LT_PERCENT,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_PERCENT,
+      anon_sym_LT_PERCENT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_POUND,
+      anon_sym_LT_PERCENT_BANG_DASH_DASH,
+      sym_text,
+  [112] = 4,
     ACTIONS(67), 1,
-      aux_sym__bang_comment_token1,
-    ACTIONS(69), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(18), 1,
-      aux_sym__bang_comment_repeat1,
-  [131] = 3,
-    ACTIONS(71), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(73), 1,
+    ACTIONS(71), 1,
+      sym__code,
+    STATE(13), 1,
+      aux_sym_partial_expression_repeat1,
+    ACTIONS(69), 2,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+  [126] = 3,
+    ACTIONS(75), 1,
+      sym__code,
+    STATE(13), 1,
+      aux_sym_partial_expression_repeat1,
+    ACTIONS(73), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+  [138] = 3,
+    ACTIONS(78), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(80), 1,
       sym__code,
     STATE(15), 1,
-      aux_sym_directive_repeat1,
-  [141] = 3,
-    ACTIONS(76), 1,
-      aux_sym__bang_comment_token1,
-    ACTIONS(78), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(14), 1,
-      aux_sym__bang_comment_repeat1,
-  [151] = 3,
-    ACTIONS(61), 1,
-      sym__code,
-    ACTIONS(80), 1,
-      anon_sym_PERCENT_GT,
-    STATE(12), 1,
-      aux_sym_directive_repeat1,
-  [161] = 3,
+      aux_sym_partial_expression_repeat1,
+  [148] = 3,
     ACTIONS(82), 1,
-      aux_sym__bang_comment_token1,
-    ACTIONS(85), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(18), 1,
-      aux_sym__bang_comment_repeat1,
-  [171] = 1,
-    ACTIONS(87), 2,
       anon_sym_PERCENT_GT,
+    ACTIONS(84), 1,
       sym__code,
-  [176] = 1,
-    ACTIONS(89), 1,
+    STATE(21), 1,
+      aux_sym_partial_expression_repeat1,
+  [158] = 3,
+    ACTIONS(86), 1,
+      aux_sym__bang_comment_token1,
+    ACTIONS(88), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(20), 1,
+      aux_sym__bang_comment_repeat1,
+  [168] = 3,
+    ACTIONS(84), 1,
+      sym__code,
+    ACTIONS(90), 1,
+      anon_sym_PERCENT_GT,
+    STATE(21), 1,
+      aux_sym_partial_expression_repeat1,
+  [178] = 3,
+    ACTIONS(92), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(94), 1,
+      sym__code,
+    STATE(17), 1,
+      aux_sym_partial_expression_repeat1,
+  [188] = 3,
+    ACTIONS(96), 1,
+      aux_sym__bang_comment_token1,
+    ACTIONS(98), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(16), 1,
+      aux_sym__bang_comment_repeat1,
+  [198] = 3,
+    ACTIONS(100), 1,
+      aux_sym__bang_comment_token1,
+    ACTIONS(103), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(20), 1,
+      aux_sym__bang_comment_repeat1,
+  [208] = 3,
+    ACTIONS(73), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(105), 1,
+      sym__code,
+    STATE(21), 1,
+      aux_sym_partial_expression_repeat1,
+  [218] = 1,
+    ACTIONS(108), 1,
+      anon_sym_PERCENT_GT,
+  [222] = 1,
+    ACTIONS(110), 1,
+      anon_sym_PERCENT_GT,
+  [226] = 1,
+    ACTIONS(112), 1,
+      anon_sym_PERCENT_GT,
+  [230] = 1,
+    ACTIONS(114), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(4)] = 0,
-  [SMALL_STATE(5)] = 13,
-  [SMALL_STATE(6)] = 26,
-  [SMALL_STATE(7)] = 39,
-  [SMALL_STATE(8)] = 52,
-  [SMALL_STATE(9)] = 65,
-  [SMALL_STATE(10)] = 78,
-  [SMALL_STATE(11)] = 91,
-  [SMALL_STATE(12)] = 101,
-  [SMALL_STATE(13)] = 111,
-  [SMALL_STATE(14)] = 121,
-  [SMALL_STATE(15)] = 131,
-  [SMALL_STATE(16)] = 141,
-  [SMALL_STATE(17)] = 151,
-  [SMALL_STATE(18)] = 161,
-  [SMALL_STATE(19)] = 171,
-  [SMALL_STATE(20)] = 176,
+  [SMALL_STATE(5)] = 21,
+  [SMALL_STATE(6)] = 34,
+  [SMALL_STATE(7)] = 47,
+  [SMALL_STATE(8)] = 60,
+  [SMALL_STATE(9)] = 73,
+  [SMALL_STATE(10)] = 86,
+  [SMALL_STATE(11)] = 99,
+  [SMALL_STATE(12)] = 112,
+  [SMALL_STATE(13)] = 126,
+  [SMALL_STATE(14)] = 138,
+  [SMALL_STATE(15)] = 148,
+  [SMALL_STATE(16)] = 158,
+  [SMALL_STATE(17)] = 168,
+  [SMALL_STATE(18)] = 178,
+  [SMALL_STATE(19)] = 188,
+  [SMALL_STATE(20)] = 198,
+  [SMALL_STATE(21)] = 208,
+  [SMALL_STATE(22)] = 218,
+  [SMALL_STATE(23)] = 222,
+  [SMALL_STATE(24)] = 226,
+  [SMALL_STATE(25)] = 230,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
-  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
-  [15] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(13),
-  [18] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(17),
-  [21] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(16),
-  [24] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(2),
-  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 2),
-  [33] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 2),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
-  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
-  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
-  [41] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
-  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
-  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2),
-  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 2),
-  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 2),
-  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [63] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
-  [65] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
-  [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2),
-  [73] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2), SHIFT_REPEAT(19),
-  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2), SHIFT_REPEAT(18),
-  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2),
-  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 1),
-  [89] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
+  [19] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(4),
+  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(14),
+  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(19),
+  [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(3),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
+  [41] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
+  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
+  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
+  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
+  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 2),
+  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 2),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 2),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 2),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 2),
+  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 2),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression, 1),
+  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2),
+  [75] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(13),
+  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [82] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [84] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [88] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 2, .production_id = 1),
+  [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
+  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2), SHIFT_REPEAT(20),
+  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bang_comment_repeat1, 2),
+  [105] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_partial_expression_repeat1, 2), SHIFT_REPEAT(21),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 1, .production_id = 1),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression, 2, .production_id = 2),
+  [114] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
@@ -666,6 +915,9 @@ extern const TSLanguage *tree_sitter_eex(void) {
     .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
+    .field_names = ts_field_names,
+    .field_map_slices = ts_field_map_slices,
+    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,

--- a/test/corpus/directives.txt
+++ b/test/corpus/directives.txt
@@ -9,3 +9,116 @@ Empty Directive
 (fragment
   (directive)
   (text))
+
+================================================================================
+Directive with just an assign
+================================================================================
+
+I am some text!
+<%= @x %>
+I am more some text!
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (text)
+  (directive
+    (expression))
+  (text))
+
+================================================================================
+Directive with a conditional block
+================================================================================
+
+<%= if @x do %>
+Hello, tree-sitter!
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression))
+  (text)
+  (directive
+    (partial_expression))
+  (text))
+
+================================================================================
+Directive with multiple case stanzas
+================================================================================
+
+<%= case @x do %>
+  <% 0 -> %> Zero
+  <% func when is_function(func) -> %> Function
+  <% _ -> %> Something else...
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression))
+  (directive
+    (partial_expression))
+  (text)
+  (directive
+    (partial_expression))
+  (text)
+  (directive
+    (partial_expression))
+  (text)
+  (directive
+    (partial_expression))
+  (text))
+
+================================================================================
+Directive with parenthesized anonymous function
+================================================================================
+
+<%= f = form_for(fn -> %>
+  <%= text_input f, :name %>
+<% end) %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression))
+  (directive
+    (expression))
+  (directive
+    (partial_expression))
+  (text))
+
+================================================================================
+Directive with unparenthesized anonymous function
+================================================================================
+
+<%= f = form_for fn -> %>
+  <%= text_input f, :name %>
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression))
+  (directive
+    (expression))
+  (directive
+    (partial_expression))
+  (text))
+
+================================================================================
+Directive containing an anonymous function is not marked as a partial expression
+================================================================================
+
+<%= evens = Enum.filter(@numbers, &Integer.is_even/1) %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (expression))
+  (text))

--- a/test/corpus/directives.txt
+++ b/test/corpus/directives.txt
@@ -122,3 +122,21 @@ Directive containing an anonymous function is not marked as a partial expression
   (directive
     (expression))
   (text))
+
+================================================================================
+Directive with partial expression and trailing comment
+================================================================================
+
+<%= if @x do # this should always be true %>
+  It's true!
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression))
+  (text)
+  (directive
+    (partial_expression))
+  (text))


### PR DESCRIPTION
replaces the `$.code` node with `$.expression` and adds `$.partial_expression` which fits any `$.expression` node that the eex tokenizer would mark as a node that spans multiple directives. I'm definitely open to debate on the node names, what do you think?

closes #1 

I expect that this will allow you to write a `queries/injections.scm` like so:

```scm
((directive (expression) @injection.content)
 (#set! injeciton.language "elixir"))

((directive (partial_expression kind: ["do" "end"]) @injection.content)
 (#set! injection.language "elixir")
 (#set! injection.combined))

((directive (expression kind: "->") @injection.content)
 (#set! injeciton.language "elixir"))
```

Although in writing the test cases it occurred to me that there may need to be a change to tree-sitter-elixir to handle a stab clause that only has a left-hand-side gracefully (I haven't tested to see if this already works yet though)