### PR TITLE
exclude tree-sitter-generated content from linguist analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/src/**/* linguist-generated=true
+/bindings/**/* linguist-generated=true


### PR DESCRIPTION
I'm stealing [this suggestion](https://github.com/elixir-lang/tree-sitter-iex/pull/6#discussion_r780687431) from Jonatan, really cleans up the PR diffs as well! (src/ and bindings/ changes get collapsed by default as "generated")