### PR TITLE
add highlight and injection queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
   "devDependencies": {
     "tree-sitter-cli": "^0.20.0",
     "nan": "^2.15.0"
-  }
+  },
+  "tree-sitter": [
+    {
+      "file-types": [
+        "eex"
+      ]
+    }
+  ]
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,4 @@
+; wrapping in (directive .. ) prevents us from highlighting '%>' in a comment as a keyword
+(directive ["<%" "<%=" "<%%" "<%%=" "%>"] @keyword)
+
+(comment) @comment

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,7 @@
+((directive (expression) @injection.content)
+ (#set! injection.language "elixir"))
+
+((partial_expression) @injection.content
+ (#set! injection.language "elixir")
+ (#set! injection.include-children)
+ (#set! injection.combined))

--- a/test/highlight/main.eex
+++ b/test/highlight/main.eex
@@ -1,0 +1,16 @@
+<%= if true do %>
+<%# <- keyword %>
+yes
+<% end %>
+
+<%= case @x do %>
+<%# <- keyword %>
+
+<% 0 -> %> Zero
+<%# <- keyword %>
+
+<% _ -> %> Something else...
+<%#     ^ keyword %>
+
+<% end %>
+<%#    ^ keyword %>


### PR DESCRIPTION
There's some odd behavior with the tree-sitter-cli highlight tests, so the highlight test file is pretty small. I think the cli thinks it should be able to test the `%>` close token of a comment which prevents you from testing multiple highlights on the same line.

<details><summary>Some examples using 'tree-sitter highlight'...</summary>

![eex-highlight](https://user-images.githubusercontent.com/21230295/148828312-af49b0fd-4d8c-4592-ba3b-63ab98426d86.png)

![eex-highlight-2](https://user-images.githubusercontent.com/21230295/148828361-19ed00c5-4d47-44d3-b09c-cb02d4be4538.png)

</details>
